### PR TITLE
Improve testing class namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
       "WGenial\\S3ObjectsStreamZip\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "WGenial\\S3ObjectsStreamZipTest\\": "tests/"
+    }
+  },
   "license": "MIT",
   "authors": [
     {

--- a/tests/S3ObjectsStreamZipTest.php
+++ b/tests/S3ObjectsStreamZipTest.php
@@ -3,7 +3,6 @@
 
   use WGenial\S3ObjectsStreamZip\S3ObjectsStreamZip;
   use WGenial\S3ObjectsStreamZip\Exception;
-  use WGenial\S3ObjectsStreamZip\Exception\InvalidParamsException;
 
   class S3ObjectsStreamZipTest extends \PHPUnit\Framework\TestCase
   {


### PR DESCRIPTION
# Changed log

- Add the `"WGenial\\S3ObjectsStreamZipTest\\"` on `autoload-dev` setting to be for testing classes.
- Removing unused `use` syntax for class namespaces.